### PR TITLE
Feature/replace profile bio with emojicode

### DIFF
--- a/client/supabase/migrations/20250419202500_rename_profiles_bio_column_to_emojicode.sql
+++ b/client/supabase/migrations/20250419202500_rename_profiles_bio_column_to_emojicode.sql
@@ -1,0 +1,10 @@
+-- ===========================================
+-- Migration:     rename_profiles_bio_column_to_emojicode
+--
+-- Description:
+--   - Renames the profiles.bio column to profiles.emojicode.
+--   - Adds a constraint to ensure that the emojicode column has a maximum length of 5 characters.
+-- ===========================================
+
+alter table public.profiles rename column bio to emojicode;
+alter table public.profiles ADD CONSTRAINT profiles_emojicode_max_length CHECK (char_length(emojicode) = 5);

--- a/client/supabase/migrations/20250419202500_rename_profiles_bio_column_to_emojicode.sql
+++ b/client/supabase/migrations/20250419202500_rename_profiles_bio_column_to_emojicode.sql
@@ -3,8 +3,12 @@
 --
 -- Description:
 --   - Renames the profiles.bio column to profiles.emojicode.
---   - Adds a constraint to ensure that the emojicode column has a maximum length of 5 characters.
+--   - Adds a constraint to ensure that the emojicode column has a maximum length of 40 characters.
+--     The limit of 40 is semi-arbitrary, but should be sufficient for most emoji code combinations.
+--     It's based on an estimate: 5 emojis × ~8 bytes = 40 bytes.
+--     We use 8 bytes per emoji to account for grapheme clusters made up of multiple code points.
+--     Fun fact: The longest emoji I found consisted of 14 code points.
 -- ===========================================
 
 alter table public.profiles rename column bio to emojicode;
-alter table public.profiles ADD CONSTRAINT profiles_emojicode_max_length CHECK (char_length(emojicode) = 5);
+alter table public.profiles ADD CONSTRAINT profiles_emojicode_max_length CHECK (char_length(emojicode) = 40);


### PR DESCRIPTION
This pull request resolves #87 by renaming the bio column to emojicode and limiting its length to 40 characters. 40 is semi-arbitrary and was calculated as 5 emojis * 8 characters per emoji (since some emojis are grapheme clusters).