### PR TITLE
Feature/delete user

### DIFF
--- a/client/supabase/migrations/20250513222500_fix_messages_sender_id.sql
+++ b/client/supabase/migrations/20250513222500_fix_messages_sender_id.sql
@@ -1,0 +1,6 @@
+ALTER TABLE messages ALTER COLUMN sender_id TYPE UUID USING sender_id::uuid;
+ALTER TABLE messages 
+    ADD CONSTRAINT fk_sender 
+    FOREIGN KEY (sender_id) 
+    REFERENCES auth.users(id) 
+    ON DELETE CASCADE;

--- a/client/supabase/migrations/20250513222500_fix_messages_sender_id.sql
+++ b/client/supabase/migrations/20250513222500_fix_messages_sender_id.sql
@@ -1,3 +1,11 @@
+-- ===========================================
+-- Migration:     fix_messages_sender_id
+--
+-- Description:
+--   This migration fixes the sender_id column in the messages table by
+--   changing its type to UUID and adding a foreign key constraint.
+-- ===========================================
+
 ALTER TABLE messages ALTER COLUMN sender_id TYPE UUID USING sender_id::uuid;
 ALTER TABLE messages 
     ADD CONSTRAINT fk_sender 

--- a/client/supabase/migrations/20250514213000_change_messages_table.sql
+++ b/client/supabase/migrations/20250514213000_change_messages_table.sql
@@ -1,0 +1,3 @@
+ALTER TABLE messages DROP COLUMN session_name;
+ALTER TABLE messages ALTER COLUMN sender_id TYPE uuid USING sender_id::uuid;
+ALTER TABLE messages ADD FOREIGN KEY (sender_id) REFERENCES auth.users(id);

--- a/client/supabase/migrations/20250514213000_change_messages_table.sql
+++ b/client/supabase/migrations/20250514213000_change_messages_table.sql
@@ -1,3 +1,0 @@
-ALTER TABLE messages DROP COLUMN session_name;
-ALTER TABLE messages ALTER COLUMN sender_id TYPE uuid USING sender_id::uuid;
-ALTER TABLE messages ADD FOREIGN KEY (sender_id) REFERENCES auth.users(id);

--- a/client/supabase/migrations/20250514213000_drop_session_name.sql
+++ b/client/supabase/migrations/20250514213000_drop_session_name.sql
@@ -1,0 +1,8 @@
+-- ===========================================
+-- Migration:     drop_session_name
+--
+-- Description:
+--   This migration modifies the messages table by removing the session_name column.
+-- ===========================================
+
+ALTER TABLE messages DROP COLUMN session_name;

--- a/server/test/database/dbhelpers.ts
+++ b/server/test/database/dbhelpers.ts
@@ -1,10 +1,16 @@
 import { createClient, SupabaseClient, User } from "@supabase/supabase-js";
+import assert from "node:assert";
 
 const url: string = "http://127.0.0.1:54321";
-const key: string = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0";
+const anon_key: string = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0";
+const service_key: string = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImV4cCI6MTk4MzgxMjk5Nn0.EGIM96RAZx35lJzdJsyH-qQwv8Hdp7fsn3W0YpN81IU";
 
 export function createClientHelper(): SupabaseClient<any, any, any> {
-  return createClient(url, key);
+  return createClient(url, anon_key);
+}
+
+export function createSuperClient(): SupabaseClient<any, any, any> {
+    return createClient(url, service_key);
 }
 
 export interface UserOptions {
@@ -43,6 +49,30 @@ export async function createUser(client: SupabaseClient<any, any, any>, settings
     return { password, user: result.data.user };
 }
 
+/**
+ * Creates a new client and creates a new user using random credentials.
+ * @return {client: SupabaseClient, user: User} The client and the user created.
+ */
+export async function setupRandomClientAndLogin(): Promise<{client: SupabaseClient<any, any, any>, user: User}> {
+  const client = createClientHelper();
+  
+  const { user, password } = await createUser(client);
+
+  if (user.email == null) {
+    throw new Error('No email returned from user creation');
+  }
+
+  const signInResult = await client.auth.signInWithPassword({
+    email: user.email!,
+    password: password,
+  });
+
+  assert.equal(signInResult.error, null, "Expected sign in to succeed, but it failed: " + signInResult.error?.message);
+
+  return {client, user};
+}
+
+
 export function generateRandomString(addDate: boolean = false): string {
     const length = 10; // Length of the random string
     const characters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789'; // Characters to choose from
@@ -57,4 +87,29 @@ export function generateRandomString(addDate: boolean = false): string {
     }
 
     return result;
+}
+
+export async function createEvent(client: SupabaseClient<any, any, any>): Promise<any> {
+    const event_to_create = {
+        title: generateRandomString(),
+        description: generateRandomString(),
+        start: new Date().toISOString(),
+        end: new Date(Date.now() + 3600000).toISOString(),
+        latitude: 50,
+        longitude: 50,
+        slot_limit: 10,
+        slots_taken: 0,
+        age_restricted: false,
+        chat_enabled: true
+    };
+
+    const { data, error } = await client.from('events')
+        .insert(event_to_create)
+        .select();
+
+    if (error) {
+        assert.ifError(error);
+    }
+
+    return (<any>data)[0];
 }

--- a/server/test/database/event.test.ts
+++ b/server/test/database/event.test.ts
@@ -1,7 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert';
-import { generateRandomString, setupRandomClientAndLogin } from './dbhelpers.js';
-import { SupabaseClient } from '@supabase/supabase-js';
+import { createEvent, setupRandomClientAndLogin } from './dbhelpers.js';
 
 test('An authenticated user can create events', async (t) => {
     const { client } = await setupRandomClientAndLogin();
@@ -108,28 +107,3 @@ test('An authenticated user can see all events', async (t) => {
         "Expected same ids but some are missing or diffrent." + response.map((event: any) => event.id)
     );
 });
-
-async function createEvent(client: SupabaseClient<any, any, any>): Promise<any> {
-    const event_to_create = {
-        title: generateRandomString(),
-        description: generateRandomString(),
-        start: new Date().toISOString(),
-        end: new Date(Date.now() + 3600000).toISOString(),
-        latitude: 50,
-        longitude: 50,
-        slot_limit: 10,
-        slots_taken: 0,
-        age_restricted: false,
-        chat_enabled: true
-    };
-
-    const { data, error } = await client.from('events')
-        .insert(event_to_create)
-        .select();
-
-    if (error) {
-        assert.ifError(error);
-    }
-
-    return (<any>data)[0];
-}

--- a/server/test/database/event_joins.test.ts
+++ b/server/test/database/event_joins.test.ts
@@ -1,7 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert';
-import { createSuperClient, generateRandomString, setupRandomClientAndLogin } from './dbhelpers.js';
-import { SupabaseClient } from '@supabase/supabase-js';
+import { createEvent, createSuperClient, setupRandomClientAndLogin } from './dbhelpers.js';
 
 test('An authenticated user can join an event', async (t) => {
     const serviceClient = createSuperClient();
@@ -160,28 +159,3 @@ test('Leaving an event decreases the slot counter', async (t) => {
     const slotsTakenResponse = <unknown>slotsTakenDaten as any[];
     assert.equal(slotsTakenResponse.length, 1, "Expected one event to be selected, but got: " + slotsTakenResponse.length);
 });
-
-async function createEvent(client: SupabaseClient<any, any, any>): Promise<any> {
-    const event_to_create = {
-        title: generateRandomString(),
-        description: generateRandomString(),
-        start: new Date().toISOString(),
-        end: new Date(Date.now() + 3600000).toISOString(),
-        latitude: 50,
-        longitude: 50,
-        slot_limit: 10,
-        slots_taken: 0,
-        age_restricted: false,
-        chat_enabled: true
-    };
-
-    const { data, error } = await client.from('events')
-        .insert(event_to_create)
-        .select();
-
-    if (error) {
-        assert.ifError(error);
-    }
-
-    return (<any>data)[0];
-}

--- a/server/test/database/users.test.ts
+++ b/server/test/database/users.test.ts
@@ -27,6 +27,15 @@ test('Delete all user data on user deletion', async (t) => {
         });
     assert.equal(eventToKeepJoinError, null, "Expected event join to succeed, but it failed: " + eventToKeepJoinError?.message);
 
+    const { error: messageAddError } = await clientToDelete.from('messages')
+        .insert({
+            chat_room_id: eventToDelete.id,
+            sender_id: userToDelete.id,
+            content: "Message to delete",
+            created_at: new Date().toISOString()
+        });
+    assert.equal(messageAddError, null, "Expected message add to succeed, but it failed: " + messageAddError?.message);
+    
     // delete and assert successful deletion
 
     const { data: deleteUserData, error: deleteUserError } = await superClient.auth.admin.deleteUser(userToDelete.id);
@@ -48,4 +57,11 @@ test('Delete all user data on user deletion', async (t) => {
         .eq('event_id', eventToDelete.id);
     assert.equal(deleteJoinsError, null, "Expected deleteJoinsError to be null, but got: " + deleteJoinsError);
     assert.equal(deleteJoinsData?.length, 0, "Expected deleteJoinsData length to be 0, but got: " + deleteJoinsData); 
+
+    // assert that the messages are deleted
+    const { data: deleteMessagesData, error: deleteMessagesError } = await superClient.from('messages')
+        .select()
+        .eq('chat_room_id', eventToDelete.id);
+    assert.equal(deleteMessagesError, null, "Expected deleteMessagesError to be null, but got: " + deleteMessagesError);
+    assert.equal(deleteMessagesData?.length, 0, "Expected deleteMessagesData length to be 0, but got: " + deleteMessagesData);
 });

--- a/server/test/database/users.test.ts
+++ b/server/test/database/users.test.ts
@@ -1,0 +1,51 @@
+import { test } from 'node:test';
+import assert from 'node:assert';
+import { createEvent, createSuperClient, setupRandomClientAndLogin } from './dbhelpers.js';
+
+test('Delete all user data on user deletion', async (t) => {
+    const superClient = await createSuperClient();
+    const { client: clientToDelete, user: userToDelete } = await setupRandomClientAndLogin();
+    const { client: clientToKeep, user: userToKeep } = await setupRandomClientAndLogin();
+    
+    const eventToDelete = await createEvent(clientToDelete);
+    const eventToKeep = await createEvent(clientToKeep);
+    
+    assert.notEqual(eventToDelete, null, "Expected eventToDelete to be not null, but got: " + eventToDelete);
+    assert.notEqual(eventToKeep, null, "Expected eventToJoin to be not null, but got: " + eventToKeep);
+        
+    const { error: eventToDeleteJoinError } = await clientToKeep.from('event_joins')
+        .insert({
+            event_id: eventToDelete.id,
+            user_id: userToKeep.id,
+        });
+    assert.equal(eventToDeleteJoinError, null, "Expected event join to succeed, but it failed: " + eventToDeleteJoinError?.message)
+
+    const { error: eventToKeepJoinError } = await clientToDelete.from('event_joins')
+        .insert({
+            event_id: eventToKeep.id,
+            user_id: userToDelete.id,
+        });
+    assert.equal(eventToKeepJoinError, null, "Expected event join to succeed, but it failed: " + eventToKeepJoinError?.message);
+
+    // delete and assert successful deletion
+
+    const { data: deleteUserData, error: deleteUserError } = await superClient.auth.admin.deleteUser(userToDelete.id);
+    assert.equal(deleteUserError, null, "Expected user deletion to succeed, but it failed: " + deleteUserError?.message);
+    assert.notEqual(deleteUserData, null, "Expected deleteData to be not null, but got: " + deleteUserData);
+
+    assert.equal((<any>deleteUserData).user.id, null, "Expected deleted_at to be null, but got: " + userToDelete.id);
+
+    // assert that the events owned by the user is deleted
+    const { data: deleteEventData, error: deleteEventError } = await superClient.from('events')
+        .select()
+        .eq('id', eventToDelete.id);
+    assert.equal(deleteEventError, null, "Expected event deletion to succeed, but it failed: " + deleteEventError?.message);
+    assert.equal(deleteEventData?.length, 0, "Expected deleteEventData to be null, but got: " + JSON.stringify(deleteEventData));
+
+    // assert that the event join is deleted
+    const { data: deleteJoinsData, error: deleteJoinsError } = await superClient.from('event_joins')
+        .select()
+        .eq('event_id', eventToDelete.id);
+    assert.equal(deleteJoinsError, null, "Expected deleteJoinsError to be null, but got: " + deleteJoinsError);
+    assert.equal(deleteJoinsData?.length, 0, "Expected deleteJoinsData length to be 0, but got: " + deleteJoinsData); 
+});


### PR DESCRIPTION
The changes in this pull request resolve #167.
As discussed, instead of providing a custom function, we now use the default Supabase delete function and cascade delete everything associated with the user.

One limitation of this solution is that we cannot delete the user account directly from the fronted, as users cannot call the supabase delete function. We will have to address this problem in the future by either providing a custom sql function that deltes the from the auth table or by adding a backend rest call.